### PR TITLE
Fixed "ruby -w" warnings.

### DIFF
--- a/lib/packaging/tasks.rb
+++ b/lib/packaging/tasks.rb
@@ -25,7 +25,7 @@ module Packaging
       def load_tasks(params = {})
         # a flag - load the tasks just once, multiple loading
         # leads to multiple invocation of the same task
-        return if @tasks_loaded
+        return if defined? @tasks_loaded
         params[:exclude] ||= []
         params[:include] ||= ["*.rake"]
         filelist = {}

--- a/lib/tasks/osc.rake
+++ b/lib/tasks/osc.rake
@@ -75,8 +75,8 @@ namespace :osc do
 
   def version_from_spec spec_glob
     version = `grep '^Version:' #{spec_glob}`
-    version.sub! /^Version:\s*/, ""
-    version.sub! /#.*$/, ""
+    version.sub!(/^Version:\s*/, "")
+    version.sub!(/#.*$/, "")
     version.strip!
     version
   end


### PR DESCRIPTION
I am converting https://github.com/mvidner/ruby-dbus to use packaging_rake_tasks and it runs everything, including `rake`, with `ruby -w`.
