### PR TITLE
Sync the gem2rpm.yml changes from IBS

### DIFF
--- a/package/gem2rpm.yml
+++ b/package/gem2rpm.yml
@@ -23,7 +23,7 @@
 #   foo.patch: -p1
 #   bar.patch: 
 # ## used by gem2rpm
-:sources:
+# :sources:
 # - foo.desktop
 # - bar.desktop
 # :gem_install_args: '....'
@@ -68,3 +68,5 @@
 #     :post: |-
 #       /bin/echo foo
 #
+---
+:license: LGPL-2.1

--- a/package/rubygem-packaging_rake_tasks.changes
+++ b/package/rubygem-packaging_rake_tasks.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon May 22 09:39:11 UTC 2017 - lslezak@suse.cz
+
+- sync the gem2rpm.yml changes from IBS
+
+-------------------------------------------------------------------
 Mon Apr 10 07:30:44 UTC 2017 - jreidinger@suse.com
 
 - sync IDs in check:changelog with build service


### PR DESCRIPTION
- An [SP3 submit request](https://build.suse.de/request/show/132953) revealed that there is change in IBS which is missing in Git.
- In the end it turned out to be just small `gem2rpm.yml` update.
- As this is trivial sync without any real change (the license is set correctly in the *.spec.in file) I'm not changing the version