### PR TITLE
[WIP] Added "osc:config" task

### DIFF
--- a/lib/tasks/osc.rake
+++ b/lib/tasks/osc.rake
@@ -226,7 +226,7 @@ namespace :osc do
     desc "Create submit request from devel project to target project without any other packaging or checking"
     task :force do
       # wait for the server service to finish to avoid "service in progress"
-      # error when creating a SR for a freshly commited package
+      # error when creating a SR for a freshly committed package
       puts "Waiting for the server side service..."
       sh "osc", "-A", obs_api, "service", "wait", obs_project, package_name
 
@@ -237,5 +237,15 @@ namespace :osc do
         sh "yes | osc -A '#{obs_api}' submitreq --no-cleanup '#{obs_project}' '#{package_name}' '#{obs_sr_project}' -m 'submit new version #{new_version}' --yes"
       end
     end
+  end
+
+  desc "Print the current packaging configuration"
+  task :config do
+    puts "Package directory: #{package_dir}"
+    puts "OBS instance:      #{obs_api}"
+    puts "OBS project:       #{obs_project}"
+    puts "OBS package name:  #{package_name}"
+    puts "OBS build target:  #{build_dist}"
+    puts "OBS submit target: #{obs_sr_project}"
   end
 end


### PR DESCRIPTION
- I'm always confused where the package will be actually submitted, it depends on the `Rakefile` config and also on the `yast-rake` package version as the targets might change.
- With this new `osc:config` task you can easily print the current config and see whether the package will be submitted to the correct project or not.

### Example

Running it in this package it shows this information:

```console
> rake osc:config
Package directory: package
OBS instance:      https://api.opensuse.org/
OBS project:       devel:languages:ruby:extensions
OBS package name:  rubygem-packaging_rake_tasks
OBS build target:  openSUSE_Tumbleweed
OBS submit target: openSUSE:Factory

```