### PR TITLE
Add support for Jira tags

### DIFF
--- a/lib/tasks/check_changelog.rake
+++ b/lib/tasks/check_changelog.rake
@@ -44,7 +44,8 @@ ID_MATCHERS = [
   /bxo#(\d+)/,
   /obs#(\d+)/,
   /build#(\d+)/,
-  /osc#(\d+)/
+  /osc#(\d+)/,
+  /jsc#([[:alpha:]]+\-\d+)/,
 ]
 
 namespace "check" do


### PR DESCRIPTION
> Suse's Jira uses tags like jsc#FOO-1234.