### PR TITLE
Fix regexp for Github references

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Similar to `build_dependencies:list` task but instead of listing them it runs
 `zypper` and installs the packages. This can used to easily install the packages
 which are needed for building the package.
 
+### check:changelog
+Checks if there is a supported issue tracker reference in the changelog when
+version in the .spec file has been changed.
+
 ### check:commited
 Checks if all changes to the local git repository are commited.
 It doesn't check if changes

--- a/lib/tasks/check_changelog.rake
+++ b/lib/tasks/check_changelog.rake
@@ -47,7 +47,7 @@ ID_MATCHERS = [
   /osc#(\d+)/,
   /jsc#([[:alpha:]]+\-\d+)/,
   /lf#(\d+)/,
-  /(?:gh|github)#(\w+\/\w+#\d+)/
+  /(?:gh|github)#([a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}\/[\w.-]+#\d+)/i
 ]
 
 namespace "check" do


### PR DESCRIPTION
## Problem

The regexp used in #54 to check a Github reference is not valid since 

* A Github username _may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen._

  ![Screenshot_2020-06-23 Build software better, together](https://user-images.githubusercontent.com/1691872/85400683-ba8c7600-b550-11ea-8f33-9c418389a3c0.png)

* A Github repository name could contain not only alpha numeric characters, but also hyphens `-`, underscores `_` and dots `.`.

  ![Screenshot_2020-06-23 Build software better, together(2)](https://user-images.githubusercontent.com/1691872/85401130-6930b680-b551-11ea-887e-d00ed63a4113.png)

## Solution

Improve the regexp.

See 

* https://stackoverflow.com/a/59082561
* https://github.com/shinnn/github-username-regex
* https://github.com/desktop/desktop/blob/d8e79651a71a0bb72878b6ed465349712be845dd/app/src/ui/add-repository/sanitized-repository-name.ts#L1-L4

## Notes

* `README` updated too.
* Version and changelog updated in #54
* An issue has been reported in OBS, see https://github.com/openSUSE/open-build-service/issues/9814

## Related to

* https://bugzilla.opensuse.org/show_bug.cgi?id=1173259
* https://github.com/yast/yast-theme/pull/128#pullrequestreview-427075123
